### PR TITLE
Drop support for Go 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.19
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.18', '1.19', '1.20', '1.21' ]
+        go: [ '1.19', '1.20', '1.21' ]
     env:
       GOFLAGS: -mod=readonly
 
@@ -49,14 +49,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Can't run race detector on windows with go 1.18 or lower due to a bug.
-      # See https://github.com/golang/go/issues/46099.
-      - name: Test Windows 1.18
-        if: ${{ matrix.os == 'windows-latest' && matrix.go == '1.18' }}
-        run: go test -v ./...
-
       - name: Test
-        if: ${{ matrix.os != 'windows-latest' || matrix.go != '1.18' }}
         run: go test -race -v ./...
 
       - name: Test disable inlining
@@ -74,7 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.19
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jxskiss/gopkg/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Change-Id: I7bc33202aacdda7e661fa575cd25f88b5c11c674